### PR TITLE
fix FR UI (bad JSON property)

### DIFF
--- a/public/fr.json
+++ b/public/fr.json
@@ -87,7 +87,7 @@
       "expire_after": "Expire après :",
       "_minutes": "minutes"
     },
-    "usine de réinitialisation": {
+    "reset_factory": {
       "reset_factory": "Réinitialiser les paramètres d'usine",
       "delete_all": "Supprimer toutes les données stockées",
       "delete_all_keep_symbols": "Supprimer tout, conserver les symboles",


### PR DESCRIPTION
I found and fix a mistake on the french translation.

When the french UI was setted, it can't reload because the json property `factory_reset` was badly set.