### PR TITLE
add-raspberry-64bit-support

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -233,11 +233,18 @@
    docker-compose -f docker-compose.server.yml up -d
    ```
 
-   라즈베리 파이 4 32bit를 사용하실 경우, 이미지를 다시 빌드하시기 바랍니다:
+   라즈베리 파이 3b+/4 **32bit**를 사용하실 경우, 이미지를 다시 빌드하시기 바랍니다:
 
    ```bash
    npm run docker:build
    docker-compose -f docker-compose.rpi.yml up -d
+   ```
+
+   라즈베리 파이 4 **64bit**를 사용하실 경우, 이미지를 다시 빌드하시기 바랍니다:
+
+   ```bash
+   npm run docker:build
+   docker-compose -f docker-compose.rpi64.yml up -d
    ```
 
    테스트 모드를 사용하실려면, 아래 명령어를 실행하시면 됩니다:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ This bot is using the concept of trailing buy/sell order which allows following 
 - The bot can monitor multiple symbols. All symbols will be monitored per second.
 - The bot is using MongoDB to provide a persistence database. However, it does not use the latest MongoDB to support Raspberry Pi 32bit. Used MongoDB version
   is 3.2.20, which is provided by [apcheamitru](https://hub.docker.com/r/apcheamitru/arm32v7-mongo).
-- The bot is tested/working with Linux and Raspberry Pi 4 32bit. Other platforms are not tested.
+- The bot is tested/working with Linux and Raspberry Pi 3b+/4 32bit. Other platforms are not tested.
 
 #### Buy Signal
 
@@ -264,11 +264,18 @@ Or use the frontend to adjust configurations after launching the application.
    docker-compose -f docker-compose.server.yml up -d
    ```
 
-   Or if using Raspberry Pi 4 32bit, must build again for Raspberry Pi:
+   Or if using Raspberry Pi 3b+/4 **32bit**, must build again for Raspberry Pi:
 
    ```bash
    npm run docker:build
    docker-compose -f docker-compose.rpi.yml up -d
+   ```
+
+   Or if using Raspberry Pi 4 **64bit**, must build again for Raspberry Pi:
+
+   ```bash
+   npm run docker:build
+   docker-compose -f docker-compose.rpi64.yml up -d
    ```
 
    Or if want development/test mode, then run below commands:

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -209,11 +209,18 @@
    docker-compose -f docker-compose.server.yml up -d
    ```
 
-   Or if using Raspberry Pi 4 32bit, must build again for Raspberry Pi:
+   Or if using Raspberry Pi 3b+/4 **32bit**, must build again for Raspberry Pi:
 
    ```bash
    npm run docker:build
    docker-compose -f docker-compose.rpi.yml up -d
+   ```
+
+   Or if using Raspberry Pi 4 **64bit**, must build again for Raspberry Pi:
+
+   ```bash
+   npm run docker:build
+   docker-compose -f docker-compose.rpi64.yml up -d
    ```
 
    Or if want development mode, then run below commands:

--- a/docker-compose.rpi64.yml
+++ b/docker-compose.rpi64.yml
@@ -1,0 +1,61 @@
+version: '3.7'
+
+services:
+  binance-bot:
+    container_name: binance-bot
+    image: chrisleekr/binance-trading-bot:latest
+    networks:
+      - internal
+    env_file:
+      - .env
+    restart: unless-stopped
+    environment:
+      # - BINANCE_MODE=test
+      - BINANCE_MODE=live
+      - BINANCE_SLACK_ENABLED=true
+      - BINANCE_JOBS_ALIVE_ENABLED=true
+      - BINANCE_JOBS_TRAILING_TRADE_ENABLED=true
+      - BINANCE_REDIS_HOST=binance-redis
+      - BINANCE_REDIS_PORT=6379
+      - BINANCE_REDIS_PASSWORD=secretp422
+    ports:
+      - 8080:80
+    logging:
+      driver: 'json-file'
+      options:
+        max-size: '10m'
+        max-file: "3"
+
+  binance-redis:
+    container_name: binance-redis
+    image: redis:6.2
+    sysctls:
+      net.core.somaxconn: 1024
+    networks:
+      - internal
+    restart: unless-stopped
+    volumes:
+      - redis_data:/data
+      - ./redis/redis.conf:/usr/local/etc/redis/redis.conf
+    command:
+      redis-server /usr/local/etc/redis/redis.conf --requirepass secretp422
+
+  binance-mongo:
+    container_name: binance-mongo
+    image: ivanmarban/armhf-mongodb
+    restart: unless-stopped
+    networks:
+      - internal
+    volumes:
+      - mongo_data:/data/db
+    #command: mongod --repair
+
+networks:
+  internal:
+    driver: bridge
+    # driver_opts:
+    #     com.docker.network.driver.mtu: 1442
+
+volumes:
+  redis_data:
+  mongo_data:


### PR DESCRIPTION
I find the correct Mongodb Docker Image which work on Raspberry Pi 4 with an 64 bit os (like Raspbian 64bit).

This is into a new .yml file.

I update some documentation also about it.
