### PR TITLE
import-export-config

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -84,7 +84,6 @@
   <script type="text/babel" src="./js/CoinWrapperSetting.js"></script>
   <script type="text/babel" src="./js/CoinWrapperChart.js"></script>
   <script type="text/babel" src="./js/CoinWrapperSellAveragedPrice.js"></script>
-
   <script type="text/babel" src="./js/CoinWrapperSellOrders.js"></script>
   <script type="text/babel" src="./js/CoinWrapperSellSignal.js"></script>
   <script type="text/babel" src="./js/CoinWrapperBuyOrders.js"></script>
@@ -97,6 +96,7 @@
   <script type="text/babel" src="./js/SymbolDeleteIcon.js"></script>
   <script type="text/babel" src="./js/SymbolEditLastBuyPriceIcon.js"></script>
   <script type="text/babel" src="./js/SymbolSettingIcon.js"></script>
+  <script type="text/babel" src="./js/ConfigManager.js"></script>
   <script type="text/babel" src="./js/CoinWrapperSymbol.js"></script>
   <script type="text/babel" src="./js/CoinWrapper.js"></script>
   <script type="text/babel" src="./js/DustTransferIcon.js"></script>

--- a/public/js/ConfigManager.js
+++ b/public/js/ConfigManager.js
@@ -1,0 +1,66 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable react/jsx-no-undef */
+/* eslint-disable no-undef */
+const ConfigManager = ({ configuration, sendWebSocket }) => {
+  const handleImport = e => {
+    if (
+      !window.confirm(
+        'This action will overwrite your current configuration. Are you sure?'
+      )
+    ) {
+      return;
+    }
+
+    const configFile = e.target.files[0];
+
+    var reader = new FileReader(); // File reader to read the file
+    // This event listener will happen when the reader has read the file
+    reader.addEventListener('load', function () {
+      const newConfig = JSON.parse(reader.result); // Parse the result into an object
+
+      // Keep some elements of last config:
+      newConfig._id = configuration._id;
+      newConfig.pastTrades = configuration.pastTrades;
+
+      // Send new config
+      sendWebSocket('setting-update', newConfig);
+
+      window.alert(
+        'Config updated! please wait a few moments or reload the page.'
+      );
+    });
+
+    reader.readAsText(configFile); // Read the uploaded file
+  };
+
+  return (
+    <div style={{ display: 'flex', 'align-items': 'flex-start' }}>
+      <input
+        type='file'
+        onChange={handleImport}
+        class='custom-file-input'
+        style={{ width: 0 }}
+        id='inputConfigElement'></input>
+      <Button
+        as='label'
+        size='sm'
+        variant='dark'
+        className='mx-1'
+        for='inputConfigElement'>
+        Import config
+      </Button>
+      <Button
+        as='a'
+        size='sm'
+        variant='dark'
+        className='mx-1'
+        download={`${new Date().toISOString().slice(0, 10)}-binance-bot-config`}
+        href={`data:application/json,${JSON.stringify({
+          ...configuration,
+          configurationDate: new Date(Date.now()).getTime()
+        })}`}>
+        Export config
+      </Button>
+    </div>
+  );
+};

--- a/public/js/SettingIcon.js
+++ b/public/js/SettingIcon.js
@@ -248,6 +248,10 @@ class SettingIcon extends React.Component {
               <Modal.Title>{setting_icon.global_settings}</Modal.Title>
             </Modal.Header>
             <Modal.Body>
+              <ConfigManager
+                configuration={configuration}
+                sendWebSocket={this.props.sendWebSocket}
+              />
               <span className='text-muted'>
                 {setting_icon.global_settings_description}
               </span>


### PR DESCRIPTION
I added a way to import / export the user configuration from setting UI.

When the configuration is loaded, the **_id** and **pastTrades** in the save are ignored.