### PR TITLE
Added LogLevel setting via Env File

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -33,3 +33,5 @@ BINANCE_FEATURE_TOGGLE_NOTIFY_ORDER_EXECUTE=true
 
 ## Password
 PASSWORD=typeyourpasswordhere
+
+LOG_LEVEL=trace

--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ Or use the frontend to adjust configurations after launching the application.
    | BINANCE_SLACK_USERNAME         | Slack username                                                            | Chris                                                                                               |
    | BINANCE_LOCAL_TUNNEL_ENABLED   | Enable/Disable [local tunnel](https://github.com/localtunnel/localtunnel) | true                                                                                                |
    | BINANCE_LOCAL_TUNNEL_SUBDOMAIN | Local tunnel public URL subdomain                                         | binance                                                                                             |
+   | LOG_LEVEL                      | Log level for Bunyan - trace (default), debug, info, warn, error, fatal   | trace                                                                                               |
 
    *A local tunnel makes the bot accessible from the outside. Please set the subdomain of the local tunnel as a subdomain that only you can remember.*
 

--- a/app/helpers/logger.js
+++ b/app/helpers/logger.js
@@ -5,7 +5,9 @@ const logger = bunyan.createLogger({
   name: 'binance-api',
   version: packageJson.version,
   serializers: bunyan.stdSerializers,
-  streams: [{ stream: process.stdout, level: bunyan.TRACE }]
+  streams: [
+    { stream: process.stdout, level: process.env.LOG_LEVEL || bunyan.TRACE }
+  ]
 });
 logger.info({ NODE_ENV: process.env.NODE_ENV }, 'API logger loaded');
 


### PR DESCRIPTION
## Description

Added LogLevel setting for Bunyan logger via the Env variable LOG_LEVEL. Defaults to TRACE, which is the current setting.

Updated .env.dist & readme to include the information regarding the LOG_LEVEL too

## Motivation and Context

Enables less disk thrashing as the logs are constantly streamed out to the machine. Should reduce some resource usage when running in a stable environment.
